### PR TITLE
Specify public base url for app and use proper history mode

### DIFF
--- a/kokartka-wyszukiwarka/src/router/index.js
+++ b/kokartka-wyszukiwarka/src/router/index.js
@@ -1,10 +1,10 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHashHistory } from 'vue-router'
 import Home from '../views/Home.vue'
 import WorkoutDesc from '../views/WorkoutDesc.vue'
 
 
 const router = createRouter({
-    history: createWebHistory(),
+    history: createWebHashHistory(import.meta.env.BASE_URL),
     routes: [{ path: '/opis/:id', component: WorkoutDesc, props: true },
     { path: '/', component: Home }]
 })

--- a/kokartka-wyszukiwarka/vite.config.js
+++ b/kokartka-wyszukiwarka/vite.config.js
@@ -4,12 +4,24 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import vueJsx from '@vitejs/plugin-vue-jsx'
 
+const APP_URL_PREFIX = '/wyszukiwarka/'
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue(), vueJsx()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  base: process.env.NODE_ENV === 'production' ? APP_URL_PREFIX : './',
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: `assets/[name].js`,
+        chunkFileNames: `assets/[name].js`,
+        assetFileNames: `assets/[name].[ext]`,
+      }
     }
   }
 })


### PR DESCRIPTION
1. Because app is deployed in a nested public path, a [base url](https://vitejs.dev/guide/build.html#public-base-path) must be specified with a proper value.
2. Vue Router [Hash History Mode](https://router.vuejs.org/guide/essentials/history-mode.html#hash-mode) was used. When HTML5 mode will be turned on, then the `#` will disappear from the URLs. As the app is deployed in a Custom Page Template, the main routing is still handled by WordPress. Which in result will return 404 on refresh
3. No matter what history mode is used, when using Vite a [base](https://router.vuejs.org/api/index.html#createwebhistory) param should always be same as `base` param from vite config.
4. Disable filename hashing